### PR TITLE
feat: add aws sam cli and supported extensions, settings, et al

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,25 +22,24 @@
       "moby": false,
       "dockerDashComposeVersion": "v2"
     },
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "./local-features/sam-cli": {},
+    "./local-features/serverless": {},
     "ghcr.io/devcontainers/features/node:1": {},
     "./local-features/np-install": {
       "packages": "serverless@latest"
     },
-    "ghcr.io/devcontainers/features/aws-cli:1": {},
-    "./local-features/serverless": {
-      "installToolsForDotnet": true
-    },
-
     "ghcr.io/dapr/cli/dapr-cli:0": {},
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
       "minikube": "none"
     },
-
     // Read more https://github.com/hashicorp/vscode-terraform/issues/1524#issuecomment-1614892272
     "ghcr.io/devcontainers/features/terraform:1": {
       "version": "latest",
       "tflint": "latest",
-      "terragrunt": "latest"
+      "terragrunt": "latest",
+      "installTFsec": true,
+      "installTerraformDocs": true
     }
   },
   "containerEnv": {
@@ -68,14 +67,8 @@
         "VisualStudioExptTeam.vscodeintellicode-insiders",
         "ms-dotnettools.vscode-dotnet-runtime",
         "ms-dotnettools.csharp",
-
-        // HINT: Installed via aws-cli feature.
-        // "AmazonWebServices.aws-toolkit-vscode",
-
-        // "ms-vscode.vscode-node-azure-pack",
         "ms-mssql.mssql",
         "humao.rest-client",
-
         "redhat.vscode-yaml",
         "editorconfig.editorconfig",
         "albert.tabout",
@@ -84,8 +77,9 @@
       ],
       // Set *default* container specific settings.json values on container create.
       "settings": {
-        "aws.telemetry": true,
-        "bicep.enableSurveys": false,
+        "aws.telemetry": false,
+        "amazonQ.telemetry": false,
+        "aws.samcli.enableCodeLenses": true,
         "redhat.telemetry.enabled": false,
         "rest-client.previewOption": "exchange",
         // Fix for ARM-based devices.
@@ -94,7 +88,6 @@
         "omnisharp.organizeImportsOnFormat": true,
         "omnisharp.useEditorFormattingSettings": true,
         "omnisharp.enableEditorConfigSupport": true,
-
         "razor.disabled": true
       }
     }
@@ -104,6 +97,13 @@
     "dev-certs": "dotnet dev-certs https --clean && dotnet dev-certs https -t",
     "clean": "rm -rf **/bin **/obj"
   },
+  // "mounts": [
+  //   {
+  //     "source": "${localEnv:HOME}${localEnv:USERPROFILE}/.aws/credentials",
+  //     "target": "/home/vscode/.aws/credentials",
+  //     "type": "bind"
+  //   }
+  // ]
   // Use 'postCreateCommand' to run commands after the container is created.
   // "postCreateCommand": {
   //   "init": "dapr init",

--- a/.devcontainer/local-features/np-install/install.sh
+++ b/.devcontainer/local-features/np-install/install.sh
@@ -7,6 +7,7 @@ NODE_PACKAGES=${PACKAGES}
 echo "Activating feature 'np-install'."
 
 # The 'install.sh' entrypoint script is always executed as the root user.
+export DEBIAN_FRONTEND=noninteractive
 
 # If packages are requested, loop thru and install globally.
 if [ ${#NODE_PACKAGES[@]} -gt 0 ]; then

--- a/.devcontainer/local-features/sam-cli/devcontainer-feature.json
+++ b/.devcontainer/local-features/sam-cli/devcontainer-feature.json
@@ -1,8 +1,8 @@
 {
-  "id": "serverless",
-  "name": "Serverless Framework",
+  "id": "sam-cli",
+  "name": "AWS Serverless CLI (SAM)",
   "version": "1.0.0",
-  "description": "Installs the Serverless Framework CLI along with needed dependencies. Useful for .NET on AWS that often written as Lambda Functions.",
+  "description": "Installs the AWS Serverless CLI (SAM) along with needed dependencies. Useful for .NET on AWS that often written as Lambda Functions.",
   "options": {
     "version": {
       "type": "string",
@@ -11,12 +11,7 @@
       ],
       "default": "latest",
       "description": "Select or enter a version."
-    },
-    "installToolsForDotnet": {
-      "type": "boolean",
-      "description": "Install AWS Tools for .NET?",
-      "default": true
-    },
+    }
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/local-features/sam-cli/install.sh
+++ b/.devcontainer/local-features/sam-cli/install.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -e
+
+SAM_VERSION=${VERSION:-"latest"}
+
+echo "Activating feature 'sam-cli@${SAM_VERSION}'"
+
+# The 'install.sh' entrypoint script is always executed as the root user.
+apt_get_update()
+{
+    echo "Running apt-get update..."
+    apt-get update -y
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" > /dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt_get_update
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+check_packages curl ca-certificates gnupg2 dirmngr unzip
+
+install() {
+    # See Linux install docs at https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html
+    GITHUB=https://github.com
+    GITHUB_REPO="${GITHUB}/aws/aws-sam-cli"
+
+    MACHINE_ARCH=$(dpkg --print-architecture)
+    case "${MACHINE_ARCH}" in
+        amd64) ARCH=x86_64 ;;
+        arm64) ARCH=arm64 ;;
+        *)
+            echo "AWS Serverless CLI (SAM) does not support machine architecture '$MACHINE_ARCH'. Please use an x86-64 or ARM64 machine."
+            exit 1
+    esac
+    TARGET=aws-sam-cli-linux-${ARCH}
+    # https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-arm64.zip
+    case "${SAM_VERSION}" in
+        latest) BINARY_URI=${GITHUB_REPO}/releases/latest/download/${TARGET}.zip ;;
+        *)      BINARY_URI=${GITHUB_REPO}/releases/download/v${SAM_VERSION}/${TARGET}.zip ;;
+    esac
+
+    curl -OL ${BINARY_URI}
+    unzip ${TARGET}.zip -d aws-sam
+    ./aws-sam/install
+}
+
+echo "(*) Installing AWS Serverless CLI (SAM)..."
+
+install
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+rm -rf ${TARGET}.zip
+rm -rf ./aws-sam
+
+echo "Done!"


### PR DESCRIPTION
this changeset is to add aws serverless cli and dependencies.

- add a local feature for aws sam cli
- add terraform extensions to improve iac activities
- add aws extensions and settings
- demonstrate aws credentials mount to local machine
- clean up dead code
