### PR TITLE
refactor: use .net version from the devcontainer feature and more

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,10 +19,9 @@
     },
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
-      "moby": false,
-      "dockerDashComposeVersion": "v2"
+      "moby": false
     },
-    "ghcr.io/devcontainers/features/dotnet:2": "lts",
+    "ghcr.io/devcontainers/features/dotnet:2": {},
     "ghcr.io/devcontainers/features/aws-cli:1": {},
     // Read more https://github.com/hashicorp/vscode-terraform/issues/1524#issuecomment-1614892272
     "ghcr.io/alertbox/opentofu/tofu:1": {}
@@ -44,37 +43,27 @@
       "extensions": [
         // .NET and C#
         "ms-dotnettools.csdevkit",
+        "humao.rest-client",
+        // Notebooks
+        "ms-dotnettools.dotnet-interactive-vscode",
         // AWS and Kubernetes
         "AmazonWebServices.aws-toolkit-vscode",
         "AmazonWebServices.amazon-q-vscode",
-        "HashiCorp.terraform",
         "mads-hartmann.bash-ide-vscode",
-        "humao.rest-client",
         // Db
         "ms-mssql.mssql",
         "ms-mssql.sql-database-projects-vscode",
-        // AI and Copilot
-        "GitHub.copilot",
         // Misc.
         "EditorConfig.EditorConfig",
         "redhat.vscode-yaml",
-        "editorconfig.editorconfig",
         "albert.tabout",
         "streetsidesoftware.code-spell-checker",
-        "redhat.fabric8-analytics",
-        // Notebooks
-        "ms-dotnettools.dotnet-interactive-vscode"
+        "redhat.fabric8-analytics"
       ],
       // Set *default* container specific settings.json values on container create.
       "settings": {
         "amazonQ.telemetry": false,
         "aws.telemetry": false,
-        "aws.samcli.enableCodeLenses": true,
-        "github.copilot.chat.agent.runTasks": true,
-        "github.copilot.chat.codeGeneration.useInstructionFiles": true,
-        "debug.internalConsoleOptions": "neverOpen",
-        "diffEditor.diffAlgorithm": "advanced",
-        "diffEditor.experimental.showMoves": true,
         "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
         "dotnet.formatting.organizeImportsOnFormat": true,
         "files.watcherExclude": {
@@ -82,16 +71,14 @@
           "**/obj/**": true
         },
         "redhat.telemetry.enabled": false,
-        "rest-client.previewOption": "exchange",
-        "scm.defaultViewMode": "tree",
         "terminal.integrated.defaultProfile.linux": "zsh",
       }
     }
   },
   // Use 'updateContentCommand' to run commands after the container is successfully created.
   "updateContentCommand": {
-    "dev-certs": "dotnet dev-certs https --clean && dotnet dev-certs https -t",
-    "clean": "rm -rf **/bin **/obj"
+    "dev-certs": "dotnet dev-certs https -t || exit 0",
+    "clean": "rm -rf **/bin **/obj || exit 0"
   },
   // "mounts": [
   //   {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,6 @@
 <Project>
   <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
   <PropertyGroup Label="Sdk">
-	  <DefaultNetCoreTargetFramework>net8.0</DefaultNetCoreTargetFramework>
 	  <IsPackable>false</IsPackable>
 	  <IsTestProject>$(MSBuildProjectName.EndsWith('.Tests'))</IsTestProject>
     <Nullable>enable</Nullable>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2023 Kosala (KP) Perera (@kosperera)
+Copyright (c) 2020 The Alertbox, Inc. (@alertbox)
+Copyright (c) 2020 It's actually me (@kosalanuwan)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ Have a suggestion or a bug fix? Just open a pull request or an issue. Include cl
 
 ## License
 
-Copyright &copy; Alertbox, Inc. (@alertbox). All rights reserved.
+Copyright &copy; The Alertbox, Inc. All rights reserved.
 
 The source code is license under the [MIT license](#MIT-1-ov-file).

--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "8.0.400",
-    "allowPrerelease": false,
-    "rollForward": "latestMinor"
-  }
-}


### PR DESCRIPTION
this changeset is to use the .net version from the devcontainer feature and clean up kubernetes related tools and extensions.

- install default .net settings from feature .net
- remove global.json
- remove .net version from bui.props
- remove kubernetes related extensions
- remove duplicates
- correct typos
- remove vs code settings that needed to be on local or user
- fix dev-certs
- remove dapr and dapr initialize
- use pr template from @alertbox org