### PR TITLE
migration: import aws and editor configurations from jakarta repo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,5 @@
 {
   "name": ".NET on AWS",
-  // See complete list https://hub.docker.com/_/microsoft-dotnet-sdk/
-  // Or https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [
@@ -70,6 +68,16 @@
           "**/bin/**": true,
           "**/obj/**": true
         },
+        "cSpell.dictionaries": [
+          "ignore"
+        ],
+        "cSpell.dictionaryDefinitions": [
+          {
+            "name": "ignore",
+            "path": "${workspaceFolder}/.spellcheckignore"
+          }
+        ],
+        "cSpell.useGitignore": true,
         "redhat.telemetry.enabled": false,
         "terminal.integrated.defaultProfile.linux": "zsh"
       }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -71,7 +71,7 @@
           "**/obj/**": true
         },
         "redhat.telemetry.enabled": false,
-        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.defaultProfile.linux": "zsh"
       }
     }
   },
@@ -80,13 +80,9 @@
     "dev-certs": "dotnet dev-certs https -t || exit 0",
     "clean": "rm -rf **/bin **/obj || exit 0"
   },
-  // "mounts": [
-  //   {
-  //     "source": "${localEnv:HOME}${localEnv:USERPROFILE}/.aws/credentials",
-  //     "target": "/home/vscode/.aws/credentials",
-  //     "type": "bind"
-  //   }
-  // ]
+  "mounts": [
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/root/.aws,type=bind,consistency=cached"
+  ],
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": {
     "restore": "dotnet restore --no-cache --force || exit 0"

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,9 +11,6 @@ charset = utf-8
 end_of_line = lf
 trim_trailing_whitespace = true
 
-# Spell checker configuration
-spelling_exclusion_path = .\.spellcheckignore
-
 # Code files
 [*.xaml]
 indent_size = 4

--- a/.spellcheckignore
+++ b/.spellcheckignore
@@ -1,0 +1,10 @@
+buildx
+devcontainers
+humao
+Makerfile
+moby
+spellcheckignore
+sqlproj
+tabout
+terragrunt
+tflint

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Start a dev container and get to developing .NET apps leveraging a [variety of Amazon services (or AWS)][aws-services-for-dotnet].
 
-[<img width="100%" 
-      alt="AWS SDK for .NET" 
+[<img width="100%"
+      alt="AWS SDK for .NET"
       src="https://github.com/alertbox/try-dotnet-on-aws/assets/958227/befa373d-72c1-4816-ade8-3abba3016b45" />][aws-sdk-for-dotnet]
 
 [Learn more about AWS SDK for .NET][aws-sdk-for-dotnet]
@@ -17,7 +17,7 @@ Start a dev container and get to developing .NET apps leveraging a [variety of A
 
 You can also run this repo locally by following these repetitive steps:
 
-1. You want to ensure the repo is cloned to your local machine, and 
+1. You want to ensure the repo is cloned to your local machine, and
 2. Open it in VS Code.
 
 >  See [.NET Docker Images][dotnet-docker-images] for other variations that suites your hardware.
@@ -46,7 +46,5 @@ Have a suggestion or a bug fix? Just open a pull request or an issue. Include cl
 [devcontainers-repo]: https://github.com/devcontainers
 
 ## License
-
-Copyright &copy; The Alertbox, Inc. All rights reserved.
 
 The source code is license under the [MIT license](#MIT-1-ov-file).

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,6 @@
+# `/build`
+
+Packaging and continuous integrations and continuous delivery;
+
+- `/ci` - Configurations and scripts.
+- `/package` - Cloud, container, OS package configurations and scripts.

--- a/src/README.md
+++ b/src/README.md
@@ -1,5 +1,6 @@
 # `/src`
 
 Your main application code and unit tests go here;
+
 - `Host/` or `App/` - Entry point, mostly the hosting project.
 - `Internal/` - Explicit internal code you do not want others to reuse.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,7 @@
 # `/tests`
 
 Benchmarks, end-to-end, and performance testing;
+
 - `benchmarks/`
 - `e2e/`
 - `performance/`


### PR DESCRIPTION
this changeset is to import from the jakarta repo.

- map aws configuration from the host device
- reconfigure spell check and ignore dictionary for vs code
- clean up editor configurations to style only
- add project layout with build folder